### PR TITLE
v0.1.3 - Bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2019-01-12
+### Changed
+- Bugfixes
+  - `Inode::meta` was not being populated causing `GetVideoMetadataMessageHandler` to trigger on already processed entries
+  - Duplicate `Title` records were inserted into db
+    - Patched code
+    - Added migration which removes duplicate records and adds an unique constraint in db
+  - Updated `composer.json`
+  - Enhanced `JAVProcessorService::extractID`
+  
+
 ## [0.1.2] - 2019-01-10
 ### Changed
 - Bugfix on the Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Calculate file hashes
 - Implemented messagebus to distribute workload over (multiple) workers
 
-[Unreleased]: https://github.com/PBXg33k/php-jav-toolbox-api/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/PBXg33k/php-jav-toolbox-api/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/PBXg33k/php-jav-toolbox-api/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/PBXg33k/php-jav-toolbox-api/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/PBXg33k/php-jav-toolbox-api/compare/v0.1.0...v0.1.1

--- a/app/composer.json
+++ b/app/composer.json
@@ -4,6 +4,7 @@
     "require": {
         "php": "^7.1.3",
         "ext-iconv": "*",
+        "ext-json": "^1.7",
         "colinodell/symfony-lts-or-current": "dev-master",
         "doctrine/collections": "^1.5",
         "doctrine/doctrine-migrations-bundle": "^1.3",

--- a/app/composer.lock
+++ b/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4fd82d6facd362d092176e511e57e99",
+    "content-hash": "cb0d92fa06100d02d46c27c4e3b2aeea",
     "packages": [
         {
             "name": "colinodell/symfony-lts-or-current",
@@ -6920,7 +6920,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.1.3",
-        "ext-iconv": "*"
+        "ext-iconv": "*",
+        "ext-json": "^1.7"
     },
     "platform-dev": []
 }

--- a/app/src/Entity/JavFile.php
+++ b/app/src/Entity/JavFile.php
@@ -37,7 +37,7 @@ class JavFile
 
     /**
      * @var ?Title
-     * @ORM\ManyToOne(targetEntity="App\Entity\Title", inversedBy="files", cascade={"persist"})
+     * @ORM\ManyToOne(targetEntity="App\Entity\Title", inversedBy="files")
      */
     private $title;
 

--- a/app/src/Migrations/Version20190111172250.php
+++ b/app/src/Migrations/Version20190111172250.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Cleans up records caused by a bug creating duplicate title records with identical catalognumber
+ */
+final class Version20190111172250 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migrations can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DELETE FROM title WHERE id IN (SELECT t.id FROM title t LEFT JOIN jav_file f on t.id = f.title_id WHERE f.path IS NULL)');
+        $this->addSql('ALTER TABLE title ADD UNIQUE INDEX idxcatno (catalognumber)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}

--- a/app/src/Service/JAVProcessorService.php
+++ b/app/src/Service/JAVProcessorService.php
@@ -147,6 +147,7 @@ class JAVProcessorService
      * @param SplFileInfo $file
      *
      * @todo lower complexity. This is a mess
+     * @todo Check for bug causing duplicate title records
      */
     public function preProcessFile(SplFileInfo $file)
     {
@@ -214,8 +215,8 @@ class JAVProcessorService
             $title->replaceFile($javFile);
             $javFile->setTitle($title);
 
-            $this->entityManager->persist($title);
-            $this->entityManager->persist($javFile);
+            $this->entityManager->merge($title);
+            $this->entityManager->merge($javFile);
             $this->entityManager->flush();
 
             $this->processFile($javFile);

--- a/app/src/Service/JAVProcessorService.php
+++ b/app/src/Service/JAVProcessorService.php
@@ -147,7 +147,6 @@ class JAVProcessorService
      * @param SplFileInfo $file
      *
      * @todo lower complexity. This is a mess
-     * @todo Check for bug causing duplicate title records
      */
     public function preProcessFile(SplFileInfo $file)
     {

--- a/app/src/Service/JAVProcessorService.php
+++ b/app/src/Service/JAVProcessorService.php
@@ -258,7 +258,7 @@ class JAVProcessorService
     private static function extractID(string $fileName): Title
     {
         //^(?:.*?)(?:(?<label>[a-z]{1,6})(?:[-\.]+)?(?<release>[0-9]{2,7})(?:[-_\]]+)?(?:.*?)?(?:0|hd|fhd|cd?)?(?:[-_]?)?(?<part>[1-9]|\W[abcdef]|[0-9]{0,3})?\.)(\w{2,5}?)$
-        if(preg_match("~^(?:.*?)((?<label>[a-z]{2,6})(?:[-\.]+)?(?<release>[0-9]{2,7})(?:[-_\]]+)?(?:.*?)?(?:0|hd|fhd|cd[-_]?)?(?<part>[1-9]|\W?[abcdef]|[0-9]{0,3})?).*?.{4,5}$~i", $fileName, $matches)) {
+        if(preg_match("~^(?:.*?)((?<label>[a-z]{2,6})(?:[-\.\s]+)?(?<release>[0-9]{2,7})(?:[-_\]]+)?(?:.*?)?(?:0|hd|fhd|cd[-_]?)?(?<part>[1-9]|\W?[abcdef]|[0-9]{0,3})?).*?.{4,5}$~i", $fileName, $matches)) {
 
             $title = (new Title())
                 ->setCatalognumber(sprintf('%s-%s', $matches['label'], $matches['release']));

--- a/app/src/Service/JAVProcessorService.php
+++ b/app/src/Service/JAVProcessorService.php
@@ -211,11 +211,11 @@ class JAVProcessorService
                     'filename'       => $file->getFilename()
                 ]);
                 $title = $javTitleInfo;
+                $this->entityManager->persist($title);
             }
             $title->replaceFile($javFile);
             $javFile->setTitle($title);
 
-            $this->entityManager->merge($title);
             $this->entityManager->merge($javFile);
             $this->entityManager->flush();
 

--- a/app/src/Service/MediaProcessorService.php
+++ b/app/src/Service/MediaProcessorService.php
@@ -115,11 +115,41 @@ class MediaProcessorService
 
             $inode = $javFile->getInode();
 
-            $inode->setMeta(json_encode([
-                'general' => $mediaInfoContainer->getGeneral()->jsonSerialize(),
-                'video'   => $mediaInfoContainer->getVideos()[0]->jsonSerialize(),
-                'audio'   => $mediaInfoContainer->getAudios()[0]->jsonSerialize()
-            ]));
+            $meta = [
+                'general'   => $mediaInfoContainer->getGeneral()->jsonSerialize(),
+                'video'     => [],
+                'audio'     => [],
+                'subtitles' => [],
+                'images'    => [],
+                'menus'     => [],
+                'others'    => []
+            ];
+
+            foreach ($mediaInfoContainer->getVideos() as $video) {
+                $meta['video'][] = $video->jsonSerialize();
+            }
+
+            foreach ($mediaInfoContainer->getAudios() as $audio) {
+                $meta['audio'][] = $audio->jsonSerialize();
+            }
+
+            foreach ($mediaInfoContainer->getSubtitles() as $subtitle) {
+                $meta['subtitles'][] = $subtitle->jsonSerialize();
+            }
+
+            foreach ($mediaInfoContainer->getImages() as $image) {
+                $meta['images'][] = $image->jsonSerialize();
+            }
+
+            foreach ($mediaInfoContainer->getMenus() as $menu) {
+                $meta['menus'][] = $menu->jsonSerialize();
+            }
+
+            foreach ($mediaInfoContainer->getOthers() as $other) {
+                $meta['others'][] = $other->jsonSerialize();
+            }
+
+            $inode->setMeta(json_encode($meta));
         } else {
             // @todo replace exception type
             throw new \Exception('Unable to load video metadata');

--- a/app/src/Service/MediaProcessorService.php
+++ b/app/src/Service/MediaProcessorService.php
@@ -112,6 +112,14 @@ class MediaProcessorService
                     'general' => $mediaInfoContainer->getGeneral(),
                 ];
             }
+
+            $inode = $javFile->getInode();
+
+            $inode->setMeta(json_encode([
+                'general' => $mediaInfoContainer->getGeneral()->jsonSerialize(),
+                'video'   => $mediaInfoContainer->getVideos()[0]->jsonSerialize(),
+                'audio'   => $mediaInfoContainer->getAudios()[0]->jsonSerialize()
+            ]));
         } else {
             // @todo replace exception type
             throw new \Exception('Unable to load video metadata');
@@ -120,22 +128,22 @@ class MediaProcessorService
         /** @var Video $vinfo */
         $vinfo = $this->videoInfo['video'][0];
         if($vinfo) {
-            $javFile->getInode()->setCodec($vinfo->get('codec'));
+            $inode->setCodec($vinfo->get('codec'));
             if($vinfo->get('duration')) {
-                $javFile->getInode()->setLength($vinfo->get('duration')->getMilliseconds());
+                $inode->setLength($vinfo->get('duration')->getMilliseconds());
             }
             if($vinfo->get('bit_rate')) {
-                $javFile->getInode()->setBitrate($vinfo->get('bit_rate')->getAbsoluteValue());
+                $inode->setBitrate($vinfo->get('bit_rate')->getAbsoluteValue());
             } elseif($vinfo->get('nominal_bit_rate')) {
-                $javFile->getInode()->setBitrate($vinfo->get('nominal_bit_rate')->getAbsoluteValue());
+                $inode->setBitrate($vinfo->get('nominal_bit_rate')->getAbsoluteValue());
             } else {
-                $javFile->getInode()->setBitrate($vinfo->get('maximum_bit_rate')->getAbsoluteValue());
+                $inode->setBitrate($vinfo->get('maximum_bit_rate')->getAbsoluteValue());
             }
-            $javFile->getInode()->setWidth($vinfo->get('width')->getAbsoluteValue());
-            $javFile->getInode()->setHeight($vinfo->get('height')->getAbsoluteValue());
+            $inode->setWidth($vinfo->get('width')->getAbsoluteValue());
+            $inode->setHeight($vinfo->get('height')->getAbsoluteValue());
             try {
                 if($frameRate = $vinfo->get('frame_rate')) {
-                    $javFile->getinode()->setFps($frameRate->getAbsoluteValue());
+                    $inode->setFps($frameRate->getAbsoluteValue());
                 } else {
                     throw
                     new \Exception("FPS unknown");


### PR DESCRIPTION
### Changed
- Bugfixes
  - `Inode::meta` was not being populated causing `GetVideoMetadataMessageHandler` to trigger on already processed entries
  - Duplicate `Title` records were inserted into db
    - Patched code
    - Added migration which removes duplicate records and adds an unique constraint in db
  - Updated `composer.json`
  - Enhanced `JAVProcessorService::extractID`